### PR TITLE
Added support for HTTPS Pushgateway endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Let's assume you have that simple counter and want to send it to your PushGatewa
     ->inc();
 
 // Now send it to the PushGateway:
-$pushGateway = new \PrometheusPushGateway\PushGateway('192.168.59.100:9091');
+$pushGateway = new \PrometheusPushGateway\PushGateway('http://192.168.59.100:9091');
 $pushGateway->push(\Prometheus\CollectorRegistry::getDefault(), 'my_job', ['instance' => 'foo']);
 ```
 
@@ -42,6 +42,11 @@ Also look at the [examples](examples).
 Just start the PushGateway by using docker-compose
 ```
 docker-compose up
+```
+
+Use composer to grab all dependencies
+```
+docker run --rm --interactive --tty --volume $PWD:/app composer install
 ```
 
 Execute the tests:

--- a/examples/pushgateway.php
+++ b/examples/pushgateway.php
@@ -22,5 +22,5 @@ $registry = new CollectorRegistry($adapter);
 $counter = $registry->registerCounter('test', 'some_counter', 'it increases', ['type']);
 $counter->incBy(6, ['blue']);
 
-$pushGateway = new PushGateway('192.168.59.100:9091');
+$pushGateway = new PushGateway('http://192.168.59.100:9091');
 $pushGateway->push($registry, 'my_job', ['instance' => 'foo']);

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:7.2-fpm
+
+RUN pecl install redis-5.3.1 && docker-php-ext-enable redis
+RUN pecl install apcu-5.1.19 && docker-php-ext-enable apcu
+
+COPY www.conf /usr/local/etc/php-fpm.d/
+COPY docker-php-ext-apcu-cli.ini /usr/local/etc/php/conf.d/

--- a/php-fpm/docker-php-ext-apcu-cli.ini
+++ b/php-fpm/docker-php-ext-apcu-cli.ini
@@ -1,0 +1,1 @@
+apc.enable_cli = On

--- a/php-fpm/www.conf
+++ b/php-fpm/www.conf
@@ -1,0 +1,6 @@
+[www]
+user = www-data
+group = www-data
+listen = 127.0.0.1:9000
+pm = static
+pm.max_children = 20

--- a/src/PrometheusPushGateway/PushGateway.php
+++ b/src/PrometheusPushGateway/PushGateway.php
@@ -25,12 +25,12 @@ class PushGateway
 
     /**
      * PushGateway constructor.
-     * @param string $address host:port of the push gateway
+     * @param string $address (http|https)://host:port of the push gateway
      * @param ClientInterface $client
      */
     public function __construct($address, ClientInterface $client = null)
     {
-        $this->address = $address;
+        $this->address = strpos($address, 'http') === false ? 'http://' . $address : $address;
         $this->client = $client ?? new Client();
     }
 
@@ -73,15 +73,15 @@ class PushGateway
     }
 
     /**
-     * @param CollectorRegistry $collectorRegistry
+     * @param CollectorRegistry|null $collectorRegistry
      * @param string $job
      * @param array $groupingKey
      * @param string $method
      * @throws GuzzleException
      */
-    private function doRequest(CollectorRegistry $collectorRegistry, string $job, array $groupingKey, $method): void
+    private function doRequest(?CollectorRegistry $collectorRegistry, string $job, array $groupingKey, $method): void
     {
-        $url = "http://" . $this->address . "/metrics/job/" . $job;
+        $url = $this->address . "/metrics/job/" . $job;
         if (!empty($groupingKey)) {
             foreach ($groupingKey as $label => $value) {
                 $url .= "/" . $label . "/" . $value;

--- a/tests/Test/BlackBoxPushGatewayTest.php
+++ b/tests/Test/BlackBoxPushGatewayTest.php
@@ -26,18 +26,19 @@ class BlackBoxPushGatewayTest extends TestCase
 
         $httpClient = new Client();
         $metrics = $httpClient->get("http://pushgateway:9091/metrics")->getBody()->getContents();
-        $this->assertContains(
+        $this->assertStringContainsString(
             '# HELP test_some_counter it increases
 # TYPE test_some_counter counter
 test_some_counter{instance="foo",job="my_job",type="blue"} 6',
             $metrics
         );
 
+        $pushGateway = new PushGateway('http://pushgateway:9091');
         $pushGateway->delete('my_job', ['instance' => 'foo']);
 
         $httpClient = new Client();
         $metrics = $httpClient->get("http://pushgateway:9091/metrics")->getBody()->getContents();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             '# HELP test_some_counter it increases
 # TYPE test_some_counter counter
 test_some_counter{instance="foo",job="my_job",type="blue"} 6',

--- a/tests/Test/PrometheusPushGateway/PushGatewayTest.php
+++ b/tests/Test/PrometheusPushGateway/PushGatewayTest.php
@@ -76,4 +76,41 @@ class PushGatewayTest extends TestCase
         $pushGateway = new PushGateway('http://foo.bar');
         $pushGateway->push($mockedCollectorRegistry, 'foo');
     }
+
+    /**
+     * @test
+     *
+     * @dataProvider validAddressAndRequestsProvider
+     */
+    public function validAddressShouldCreateValidRequests(string $address, string $scheme, string $host, int $port): void
+    {
+        $mockedCollectorRegistry = $this->createMock(CollectorRegistry::class);
+        $mockedCollectorRegistry->method('getMetricFamilySamples')->with()->willReturn([
+            $this->createMock(MetricFamilySamples::class)
+        ]);
+
+        $mockHandler = new MockHandler([
+            new Response(200),
+        ]);
+        $handler = HandlerStack::create($mockHandler);
+        $client = new Client(['handler' => $handler]);
+
+        $pushGateway = new PushGateway($address, $client);
+        $pushGateway->push($mockedCollectorRegistry, 'foo');
+
+        $uri = $mockHandler->getLastRequest()->getUri();
+        $this->assertEquals($scheme, $uri->getScheme());
+        $this->assertEquals($host, $uri->getHost());
+        $this->assertEquals($port, $uri->getPort());
+        $this->assertEquals('/metrics/job/foo', $uri->getPath());
+    }
+
+    public function validAddressAndRequestsProvider()
+    {
+        return [
+            ['foo.bar:123', 'http', 'foo.bar', 123],
+            ['http://foo.bar:123', 'http', 'foo.bar', 123],
+            ['https://foo.bar:123', 'https', 'foo.bar', 123],
+        ];
+    }
 }


### PR DESCRIPTION
This solves the issue with the Pushgateway endpoint being hardcoded to a http endpoint.
```
1) Test\BlackBoxPushGatewayTest::pushGatewayShouldWork
GuzzleHttp\Exception\ClientException: Client error: `PUT http://super-secure-pushgateway:443/metrics/job/my_job/instance/foo` resulted in a `400 Bad Request` response:
(truncated...)
```

I also brought over the missing `php-fpm` directory from PromPHP/prometheus_client_php repo.
