### PR TITLE
Move default timeouts from request to client configuration.

### DIFF
--- a/src/PrometheusPushGateway/PushGateway.php
+++ b/src/PrometheusPushGateway/PushGateway.php
@@ -34,7 +34,7 @@ class PushGateway
     public function __construct(string $address, ?ClientInterface $client = null)
     {
         $this->address = strpos($address, 'http') === false ? 'http://' . $address : $address;
-        $this->client = $client ?? new Client();
+        $this->client = $client ?? new Client(['connect_timeout' => 10, 'timeout' => 20]);
     }
 
     /**
@@ -95,8 +95,6 @@ class PushGateway
             'headers' => [
                 'Content-Type' => RenderTextFormat::MIME_TYPE,
             ],
-            'connect_timeout' => 10,
-            'timeout' => 20,
         ];
 
         if ($method !== self::HTTP_DELETE && $collectorRegistry !== null) {


### PR DESCRIPTION
The current implementation does not allow the configuration of custom timeouts since they are set to 20s/10s for each request. Passing in a custom client with specified timeouts does not change the timeout since they are overridden. In some scenarios, it is desirable to have shorter timeouts to avoid stalling the processing of requests/jobs.

This change should not modify the library's default behaviour but moving the timeouts into the client configuration allows the customization of the values by providing a different instance of the Guzzle client.